### PR TITLE
Add sudo to pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ```
 sudo apt-get install bc coreutils dosfstools e2fsprogs fdisk kpartx mtools ninja-build pkg-config python3-pip
-pip3 install meson mako jinja2 ply pyyaml
+sudo pip3 install meson mako jinja2 ply pyyaml
 ```
 
 3. Initialize repo:


### PR DESCRIPTION
When you install `meson` without root privileges via pip, it is not found when invoked via `$ meson`.

Found this out the hard way, at 91% in a build.