### PR TITLE
Added Missing Dependencies of libncurses.so.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 2. Install additional packages:
 
 ```
-sudo apt-get install bc coreutils dosfstools e2fsprogs fdisk kpartx mtools ninja-build pkg-config python3-pip
+sudo apt-get install bc coreutils dosfstools e2fsprogs fdisk kpartx mtools ninja-build pkg-config python3-pip libncurses5
 sudo pip3 install meson mako jinja2 ply pyyaml
 ```
 


### PR DESCRIPTION
Build was failing due to below missing dependencies on Ubuntu 20.04. Adding "sudo apt-get install libncurses5" for issue resolution.

"prebuilts/clang/host/linux-x86/clang-3289846/bin/clang.real: error while loading shared libraries: libncurses.so.5: cannot open shared object 
file: No such file or directory"