### PR TITLE
libcamera build issue - pin meson to version 1.2.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ```
 sudo apt-get install bc coreutils dosfstools e2fsprogs fdisk kpartx mtools ninja-build pkg-config python3-pip
-sudo pip3 install meson mako jinja2 ply pyyaml dataclasses
+sudo pip3 install meson==1.2.3 mako jinja2 ply pyyaml dataclasses
 ```
 
 3. Initialize repo:


### PR DESCRIPTION
Temporarily pin meson to version 1.2.3 as more recent versions lead to build issues.