### PR TITLE
Update README.md: Include rsync in additional packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 2. Install additional packages:
 
 ```
-sudo apt-get install bc coreutils dosfstools e2fsprogs fdisk kpartx mtools ninja-build pkg-config python3-pip
+sudo apt-get install bc coreutils dosfstools e2fsprogs fdisk kpartx mtools ninja-build pkg-config python3-pip rsync
 sudo pip3 install meson mako jinja2 ply pyyaml dataclasses
 ```
 


### PR DESCRIPTION
Hi,
I added `rsync` to the list of required packages because I encountered the following error when building without it in a Docker container:

```
/bin/sh: 1: rsync: not found
10:47:56 ninja failed with: exit status 1
```

Thank you!